### PR TITLE
Fix: IAM group membership name, use id in name

### DIFF
--- a/aws/resources.go
+++ b/aws/resources.go
@@ -1904,10 +1904,11 @@ func iamGroupMemberships(ctx context.Context, a *aws, resourceType string, filte
 		importer := &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				groupName := d.Id()
+				membershipID := resource.UniqueId()
 
 				d.Set("group", groupName)
-				d.SetId(resource.UniqueId())
-
+				d.SetId(membershipID)
+				d.Set("name", membershipID)
 				return []*schema.ResourceData{d}, nil
 			},
 		}


### PR DESCRIPTION

1. `IAMUserGroupMembership` and `IAMGroupMembership` are terraform things and not actual resource in the aws cloud.
2. `IAMUserGroupMembership` doesn't have name attribute
3. `IAMGroupMembership` has the name and id as same when we did testing using plan/apply.
4. Terraform keeps track of this as a resource in the statefile for itself. Even if the name/id are changed and the user and group association exists, there would be no changes/recreation on aws cloud, even though terraform might show diff.
5. To fix the required field name in  IAMGroupMembership we copied the id in the name as a solution 
6. Thing to note, even the id is randomly generated by terracognita while importing this resource for obvious reason

