### PR TITLE
Continuation of Flow upon Failure in One Resource

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -119,7 +119,7 @@ func (g *google) Resources(ctx context.Context, t string, f *filter.Filter) ([]p
 
 		}
 
-		return nil, errors.Wrapf(err, "error while reading from resource %q", t)
+		return nil, errors.Wrapf(unwrapErr, " ")
 	}
 
 	return resources, nil

--- a/provider/import.go
+++ b/provider/import.go
@@ -169,7 +169,7 @@ func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filt
 						// skip access denied errors, since we might not have access to all resources when trying to import based on tags
 						logger.Debug("unable to import resource, access denied", "error", err)
 					} else {
-						return fmt.Errorf("error while fetching the resources of type: %s: %w", t, err)
+						logger.Info(" ", "error", err, "resource_type", t)
 					}
 				}
 			}

--- a/provider/import.go
+++ b/provider/import.go
@@ -169,7 +169,7 @@ func Import(ctx context.Context, p Provider, hcl, tfstate writer.Writer, f *filt
 						// skip access denied errors, since we might not have access to all resources when trying to import based on tags
 						logger.Debug("unable to import resource, access denied", "error", err)
 					} else {
-						logger.Info(" ", "error", err, "resource_type", t)
+						logger.Warn("failed to fetch the resource type", "error", err, "resource_type", t)
 					}
 				}
 			}


### PR DESCRIPTION
Improved error message view.
Not breaking the flow if a particular resource import fails.